### PR TITLE
Docker-compose & Ahoy

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -1,0 +1,66 @@
+ahoyapi: v2
+
+commands:
+  build:
+    cmd: |
+      docker-compose -f dev-docker-compose.yml up -d --build
+      ahoy install
+    usage: Build the docker-compose containers.
+
+  up:
+    cmd: docker-compose -f dev-docker-compose.yml up -d
+    usage: Start the docker-compose containers.
+
+  stop:
+    cmd: docker-compose -f dev-docker-compose.yml stop
+    usage: Stop the docker-compose containers.
+
+  down:
+    cmd: docker-compose -f dev-docker-compose.yml down
+    usage: Destroy the docker-compose containers.
+
+  ps:
+    cmd: docker-compose -f dev-docker-compose.yml ps
+    usage: Show docker-compose containers.
+
+  logs:
+    cmd: docker-compose -f dev-docker-compose.yml logs
+    usage: Show logs for the docker-compose containers.
+  
+  restart:
+    cmd: docker-compose -f dev-docker-compose.yml restart
+    usage: Restart the docker-compose containers.
+
+  cli:
+    cmd: docker-compose -f dev-docker-compose.yml exec openfisca bash
+    usage: Start a shell in the container (like ssh without actual ssh).
+
+  run:
+    cmd: docker-compose -f dev-docker-compose.yml exec openfisca bash -c "$*"
+    usage: Run a command in the container
+
+  install:
+    cmd: ahoy run "pip install --upgrade pip build twine && pip install --upgrade --editable .[dev] --use-deprecated=legacy-resolver"
+    usage: Install OpenFisca-Aotearoa for development
+
+  test:
+    cmd: |
+      ahoy check-syntax-errors
+      ahoy check-style
+      ahoy run "openfisca test --country-package openfisca_aotearoa openfisca_aotearoa/tests/${1:-*}"
+    usage:
+      Run tests within the container. Optional parameter to run specific tests using relative path
+      eg. ahoy test social_security
+      eg. ahoy test social_security/jobseeker_support.yaml
+
+  check-syntax-errors:
+    cmd: ahoy run "make check-syntax-errors"
+    usage: Check syntax errors
+
+  format-style:
+    cmd: ahoy run "make format-style"
+    usage: Format style
+
+  check-style:
+    cmd: ahoy run "make check-style"
+    usage: Check style

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM python:3-stretch
+FROM python:3.10
+
 COPY . /openfisca
 WORKDIR /openfisca
 
 RUN pip install --upgrade pip && \
-    pip install -e .
-    
+    pip install . --use-deprecated=legacy-resolver
+
 EXPOSE 5000
 
 CMD [ "/usr/local/bin/openfisca", "serve", "-b", "0.0.0.0:5000" ]

--- a/README.md
+++ b/README.md
@@ -5,23 +5,38 @@
 
 Requirements:
 
+* Ahoy
+  https://ahoy-cli.readthedocs.io/en/latest/#installation
+
 * Docker
 
 ```
-# Using the `Dockerfile` in this repo build a docker container tagged/named `openfisca`
-docker build . -t openfisca 
+# Using the `dev-docker-compose.yml` in this repo to configure and build the `openfisaca` container
+ahoy build
 
-# to run openfisca and connect log/error output to your terminal
-docker run -v ${PWD}:/openfisca -p 5000:5000 -t openfisca
+# to run openfisca container background
+ahoy up
 
-# To run in background (see it running using `docker ps` and logs with `docker logs openfisca`
-docker run -v ${PWD}:/openfisca -p 5000:5000 -t openfisca -d 
+# to view openfisca logs
+ahoy logs
 
+# Attach to openfisca container
+ahoy cli
+
+# Run a command in the openfisca container
+ahoy run "openfisca --help"
+
+# Install dev requirements for tests
+ahoy install
+
+# Run tests
+ahoy test
 ```
 
-*Note that we're using -v to map the local directory inside of the container 
-so you shouldn't have to rebuild the container while developing and 
-testing changes in your development environment. If you have something running locally on port 5000, you can change the `-p 5000:5000` to an unocupied local port like 5005 like this: `-p 5005:5000`*
+*Note that we're using `volumes:` property in `dev-docker-compose.yml` to map the local directory inside of the container 
+so you shouldn't have to rebuild the container while developing and testing changes in your development environment. 
+If you have something running locally on port 5000, you can change the `ports:` property in `dev-docker-compose.yml` 
+`- 5000:5000` to an unoccupied local port like 5005 like this: `- 5005:5000`*
 
 
 ## Writing the Legislation

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3"
+
+services:
+  openfisca:
+    build:
+      context: .
+    ports:
+      - 5000:5000
+    working_dir:
+      /openfisca
+    volumes:
+      - ./:/openfisca


### PR DESCRIPTION
I am proposing we use [docker-compose](https://docs.docker.com/compose/) to manage the docker configuration and [ahoy](https://ahoy-cli.readthedocs.io/en/latest/) to use common commands to manage docker.

I know we only have one service for openfisca and docker-compose is more intended for multiple docker services. 
Still, I find it easier to use the YAML file to config docker and also I think the docker-compose commands are more straightforward.
e.g. `docker build . -t openfisca` vs `docker-compose build`
eg. `docker run -v ${PWD}:/openfisca -p 5000:5000 -t openfisca` vs `docker-compose up`

But let me know what you think cause we can easily update the ahoy commands to use docker commands instead of docker-compose commands etc.
Also, I see we have a Makefile in the project so we could migrate the ahoy commands into this file but I have chosen ahoy as I have more experience with this and we can call Makefile commands from ahoy.

For any new contributors or testers, it's straightforward for them to clone the repo and create the dev environment with just a few ahoy commands.
```
git clone https://github.com/govzeroaotearoa/openfisca-aotearoa.git
cd openfisca-aotearoa
ahoy build
ahoy test
```