### PR TITLE
Restoration of old citizenship and immigration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# 13.0.1 - [30](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/30)
+* Restoration of Citizen and Immigration tests to utilise functionality added in OpenFisca core.
+
 # 13.0.0 - [29](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/29)
 * Large restructure and renaming exercise to lay groundwork for social security act work.
 * Switch away from using act numbers for folders to using prefixes. New version of social security act forced this.

--- a/openfisca_aotearoa/tests/citizenship/citizenship_leap_days.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_leap_days.yaml
@@ -6,9 +6,9 @@
     persons:
       "Tahi":
         present_in_new_zealand:
-          "2001-01-01": true
+          "day:2013-01-01:1522": true
         immigration__entitled_to_indefinite_stay:
-          "2001-01-01": true
+          "day:2013-01-01:1522": true
   output:
     days_present_in_new_zealand_in_preceeding_year:
       "2014-02-28": 365

--- a/openfisca_aotearoa/tests/citizenship/citizenship_more.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_more.yaml
@@ -9,33 +9,33 @@
         full_capacity: true
         # 242 days in NZ
         present_in_new_zealand:
-          "2013-02-04": true
-          "2014-03-10": false
-          "2014-03-15": true
-          "2015-08-30": true
-          "2016-03-10": false
-          "2016-03-15": true
-          "2016-08-27": false
-          "2016-11-02": false
-          "2016-11-16": true
-          "2017-05-27": false
-          "2017-06-20": true
-          "2018-01-21": false
-          "2018-02-12": true
+          "day:2013-02-04:399": true
+          "day:2014-03-10:5": false
+          "day:2014-03-15:533": true
+          "day:2015-08-30:193": true
+          "day:2016-03-10:5": false
+          "day:2016-03-15:165": true
+          "day:2016-08-27:67": false
+          "day:2016-11-02:14": false
+          "day:2016-11-16:192": true
+          "day:2017-05-27:24": false
+          "day:2017-06-20:215": true
+          "day:2018-01-21:22": false
+          "day:2018-02-12": true
         immigration__entitled_to_indefinite_stay:
-          "2013-02-04": true
-          "2014-03-10": false
-          "2014-03-15": true
-          "2015-08-30": true
-          "2016-03-10": false
-          "2016-03-15": true
-          "2016-08-27": false
-          "2016-11-02": false
-          "2016-11-16": true
-          "2017-05-27": false
-          "2017-06-20": true
-          "2018-01-21": false
-          "2018-02-12": true
+          "day:2013-02-04:399": true
+          "day:2014-03-10:5": false
+          "day:2014-03-15:533": true
+          "day:2015-08-30:193": true
+          "day:2016-03-10:5": false
+          "day:2016-03-15:165": true
+          "day:2016-08-27:67": false
+          "day:2016-11-02:14": false
+          "day:2016-11-16:192": true
+          "day:2017-05-27:24": false
+          "day:2017-06-20:215": true
+          "day:2018-01-21:22": false
+          "day:2018-02-12": true
   output:
     # citizenship__minimum_presence_requirements:
     #   "2017-10-01": true

--- a/openfisca_aotearoa/tests/citizenship/citizenship_presence.yaml
+++ b/openfisca_aotearoa/tests/citizenship/citizenship_presence.yaml
@@ -9,17 +9,20 @@
         full_capacity: true
         # 242 days in NZ
         present_in_new_zealand:
-          "2015-01-01": true
-          "2021-08-29": false
+          "day:2015-01-01:2432": true
+          "day:2021-08-29:2000": false
         citizenship__intends_to_reside_in_nz: true
         citizenship__sufficient_knowledge_english_language: true
         citizenship__sufficient_knowledge_responsibilities_and_privileges: true
         citizenship__of_good_character: true
         immigration__entitled_to_indefinite_stay:
-          "2015-01-01": true
-          "2021-08-29": false
+          "day:2015-01-01:2432": true
+          "day:2021-08-29:2000": false
   output:
-    citizenship__citizenship_by_grant_may_be_authorized:
+    citizenship__5_year_presence_requirement:
+      "2019-01-01": true
+      "2020-01-01": true
+    citizenship__each_year_minimum_presence_requirements:
       "2019-01-01": false
       "2020-01-01": true
       "2021-01-01": true
@@ -33,16 +36,13 @@
       "2022-01-01": true
       "2023-01-01": false
       "2024-01-01": false
-    citizenship__each_year_minimum_presence_requirements:
+    citizenship__citizenship_by_grant_may_be_authorized:
       "2019-01-01": false
       "2020-01-01": true
       "2021-01-01": true
       "2022-01-01": true
       "2023-01-01": false
       "2024-01-01": false
-    citizenship__5_year_presence_requirement:
-      "2019-01-01": true
-      "2020-01-01": true
 
     days_present_in_new_zealand_in_preceeding_year:
       "2014-12-30": 0

--- a/openfisca_aotearoa/tests/immigration/indefinite_stay_enter_and_leave.yaml
+++ b/openfisca_aotearoa/tests/immigration/indefinite_stay_enter_and_leave.yaml
@@ -5,17 +5,16 @@
     persons:
       "Tahi":
         present_in_new_zealand:
-          "2001-01-01": true
-          "2013-03-31": false
-          "2013-05-05": true
-          "2015-06-20": false
+          "day:2001-01-01:4472": true
+          "day:2013-03-31:35": false
+          "day:2013-05-05:776": true
+          "day:2015-06-20:11": false
           "2015-07-01": true
-
         immigration__entitled_to_indefinite_stay:
-          "2001-01-01": true
-          "2013-03-31": false
-          "2013-05-05": true
-          "2015-06-20": false
+          "day:2001-01-01:4472": true
+          "day:2013-03-31:35": false
+          "day:2013-05-05:776": true
+          "day:2015-06-20:11": false
           "2015-07-01": true
   output:
     was_present_in_nz_and_entitled_to_indefinite_stay:

--- a/openfisca_aotearoa/tests/immigration/indefinite_stay_present_not_entitled.yaml
+++ b/openfisca_aotearoa/tests/immigration/indefinite_stay_present_not_entitled.yaml
@@ -4,18 +4,17 @@
     persons:
       "Tahi":
         present_in_new_zealand:
-          "2001-01-01": true
-          "2013-01-31": false
-          "2013-02-05": true
-          "2015-02-20": false
-          "2015-03-01": true
-
+          "day:2001-01-01:4413": true
+          "day:2013-01-31:5": false
+          "day:2013-02-05:745": true
+          "day:2015-02-20:9": false
+          "day:2015-03-01:17": true
         immigration__entitled_to_indefinite_stay:
-          "2001-01-01": true
-          "2013-01-31": false
-          "2013-02-10": true
-          "2015-02-20": false
-          "2015-03-15": true
+          "day:2001-01-01:4413": true
+          "day:2013-01-31:10": false
+          "day:2013-02-10:740": true
+          "day:2015-02-20:23": false
+          "day:2015-03-15:2": true
   output:
     was_present_in_nz_and_entitled_to_indefinite_stay:
       "2000-12-01": false

--- a/openfisca_aotearoa/variables/acts/citizenship/citizenship.py
+++ b/openfisca_aotearoa/variables/acts/citizenship/citizenship.py
@@ -1,5 +1,5 @@
 """TODO: Add missing doctring."""
-from openfisca_core.periods import DAY, ETERNITY
+from openfisca_core.periods import DAY, ETERNITY, DateUnit
 from openfisca_core.variables import Variable
 from openfisca_aotearoa.variables.demographics.residence import days_since_n_years_ago
 from openfisca_aotearoa.entities import Person
@@ -23,13 +23,13 @@ class citizenship__citizenship_by_grant_may_be_authorized(Variable):
     def formula_2005_04_20(persons, period, parameters):
 
         return (persons("age", period) >= parameters(period).citizenship.by_grant.minimum_age_threshold) * \
-            persons("full_capacity", period) * \
+            persons("full_capacity", DateUnit.ETERNITY) * \
             persons("citizenship__minimum_presence_requirements", period) * \
-            persons("citizenship__of_good_character", period) * \
-            persons("citizenship__sufficient_knowledge_responsibilities_and_privileges", period) * \
-            persons("citizenship__sufficient_knowledge_english_language", period) * \
-            (persons("citizenship__intends_to_reside_in_nz", period) + persons("citizenship__intends_crown_service", period)
-                + persons("citizenship__intends_international_service", period) + persons("citizenship__intends_nz_employment", period))
+            persons("citizenship__of_good_character", DateUnit.ETERNITY) * \
+            persons("citizenship__sufficient_knowledge_responsibilities_and_privileges", DateUnit.ETERNITY) * \
+            persons("citizenship__sufficient_knowledge_english_language", DateUnit.ETERNITY) * \
+            (persons("citizenship__intends_to_reside_in_nz", DateUnit.ETERNITY) + persons("citizenship__intends_crown_service", DateUnit.ETERNITY)
+                + persons("citizenship__intends_international_service", DateUnit.ETERNITY) + persons("citizenship__intends_nz_employment", DateUnit.ETERNITY))
 
 
 class citizenship__minimum_presence_requirements(Variable):
@@ -74,7 +74,7 @@ class citizenship__each_year_minimum_presence_requirements(Variable):
             # print("days present on rolling year ending at", day_n_years_ago, "is", days_present)
 
             meets_presence_n_years_ago = (days_present >= required_days)
-            # print("Meets rquirement??", meets_presence_n_years_ago)
+            # print("Meets requirement??", meets_presence_n_years_ago)
 
             # Accumulate the each year
             meets_presence = meets_presence_n_years_ago * meets_presence

--- a/openfisca_aotearoa/variables/acts/immigration/indefinite_stay.py
+++ b/openfisca_aotearoa/variables/acts/immigration/indefinite_stay.py
@@ -1,14 +1,15 @@
 """TODO: Add missing doctring."""
 
-from openfisca_core.periods import DAY
-from openfisca_core.variables import Variable
+from openfisca_core import periods, variables
+from openfisca_core.holders import set_input_dispatch_by_period
 
 from openfisca_aotearoa.entities import Person
 
 
-class immigration__entitled_to_indefinite_stay(Variable):
+class immigration__entitled_to_indefinite_stay(variables.Variable):
     value_type = bool
     entity = Person
-    definition_period = DAY
+    definition_period = periods.DAY
     label = "is entitled in terms of the Immigration Act 2009 to be in New Zealand indefinitely"
     reference = "http://www.legislation.govt.nz/act/public/2009/0051/latest/DLM1440303.html"
+    set_input = set_input_dispatch_by_period

--- a/openfisca_aotearoa/variables/demographics/residence.py
+++ b/openfisca_aotearoa/variables/demographics/residence.py
@@ -5,7 +5,7 @@
 # For more information on OpenFisca's available modules:
 # https://openfisca.org/doc/openfisca-python-api/index.html
 from openfisca_core import periods, variables
-
+from openfisca_core.holders import set_input_dispatch_by_period
 from datetime import timedelta
 
 # We import the required `entities` corresponding to our formulas.
@@ -113,3 +113,4 @@ class present_in_new_zealand(variables.Variable):
     default_value = False
     label = "was present in New Zealand on this day"
     reference = "http://www.legislation.govt.nz/act/public/1977/0061/latest/DLM443855.html"
+    set_input = set_input_dispatch_by_period

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Aotearoa",
-    version = "13.0.0",
+    version = "13.0.1",
     author = "New Zealand Government, Service Innovation Lab",
     author_email = "brenda.wallace@dia.govt.nz,hamish.fraser@dia.govt.nz",
     description = "OpenFisca tax and benefit system for Aotearoa",


### PR DESCRIPTION
Thanks for contributing to OpenFisca ! Please remove this line, as well as, for each line below, the cases which are not relevant to your contribution :)

* Tax and benefit system evolution. Minor change.
* Impacted periods: all
* Impacted areas: `tests/citizenship, tests/immigration`
* Details:
  - Restored old tests with adjustments to suit changes in OpenFisca Core
  - added setup_input to immigration__entitled_to_indefinite_stay and present_in_new_zealand

- - - -

These changes :

- Fix or improve an already existing calculation.
- Change non-functional parts of this repository (for instance editing the README)
