### PR TITLE
person_has_partner converted to week from month

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+# 16.0.1 - [36](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/35)
+* Change to variable `person_has_partner` - time period switched from month to week
+
+# Changelog
 # 16.0.0 - [35](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/35)
 * Change to contributing.md and coding patterns
 * Updated spelling of dependant to dependent when used as an adjective

--- a/openfisca_aotearoa/tests/demographics/relationships.yaml
+++ b/openfisca_aotearoa/tests/demographics/relationships.yaml
@@ -1,23 +1,23 @@
 - name: Relationship status
-  period: "2018-10"
+  period: "2018-W40"
   absolute_error_margin: 0
   input:
     persons:
       Mama:
         age:
-          "2017-10-01": 30
+          "day:2017-10-01:7": 30
       Papa:
         age:
-          "2017-10-01": 30
+          "day:2017-10-01:7": 30
       Bob:
         age:
-          "2017-10-01": 30
+          "day:2017-10-01:7": 30
       Fred:
         age:
-          "2017-10-01": 30
+          "day:2017-10-01:7": 30
       Mary:
         age:
-          "2017-10-01": 30
+          "day:2017-10-01:7": 30
     families:
       One:
         principal: Mama

--- a/openfisca_aotearoa/variables/acts/income_tax/family_scheme/family_scheme.py
+++ b/openfisca_aotearoa/variables/acts/income_tax/family_scheme/family_scheme.py
@@ -53,7 +53,7 @@ class family_scheme__full_time_earner(Variable):
     reference = "http://legislation.govt.nz/act/public/2007/0097/latest/DLM1518419.html"
 
     def formula(persons, period, parameters):
-        has_partner = (persons("person_has_partner", period) > 0)
+        has_partner = (persons("person_has_partner", period.first_week) > 0)
         hours_per_week_threshold = parameters(period).entitlements.social_security.family_scheme.hours_per_week_threshold
         hours_per_week_threshold_with_partner = parameters(period).entitlements.social_security.family_scheme.hours_per_week_threshold_with_partner
 

--- a/openfisca_aotearoa/variables/acts/social_security/interpretation/relationship.py
+++ b/openfisca_aotearoa/variables/acts/social_security/interpretation/relationship.py
@@ -15,7 +15,7 @@ class social_security__in_a_relationship(variables.Variable):
     set_input = holders.set_input_dispatch_by_period
 
     def formula(persons, period, parameters):
-        return persons("person_has_partner", period.first_month)
+        return persons("person_has_partner", period)
 
 
 class social_security__been_married_or_civil_union_or_de_facto_relationship(variables.Variable):

--- a/openfisca_aotearoa/variables/acts/social_security/sole_parent_support/sole_parent_support.py
+++ b/openfisca_aotearoa/variables/acts/social_security/sole_parent_support/sole_parent_support.py
@@ -73,7 +73,7 @@ class sole_parent_support__meets_relationship_qualification(variables.Variable):
     """
     def formula(persons, period, parameters):
         # Do they have a partner
-        no_partners = (persons("person_has_partner", period) == 0)
+        no_partners = (persons("person_has_partner", period.first_week) == 0)
         not_supported = (persons("is_adequately_supported_by_partner", period) == 0)
         # no partner, OR not supported by partner
         return no_partners + not_supported

--- a/openfisca_aotearoa/variables/demographics/relationships.py
+++ b/openfisca_aotearoa/variables/demographics/relationships.py
@@ -10,7 +10,7 @@ class person_has_partner(variables.Variable):
     value_type = bool
     entity = entities.Person
     label = "Common definition of 'in a relationship', note can also be set to true through use of the partner role in a family"
-    definition_period = periods.MONTH  # This variables.variable changes over time.
+    definition_period = periods.WEEK  # This variables.variable changes over time.
     reference = "This is a common definition utilsed in at least both the Social Security Act 2018 and the Income Tax Act 2007"
 
     def formula(persons, period, parameters):


### PR DESCRIPTION
Thanks for contributing to OpenFisca ! Please remove this line, as well as, for each line below, the cases which are not relevant to your contribution :)

* Minor change.
* Impacted periods: all.
* Impacted areas: `openfisca_aotearoa/variables/demographics`
* Details:
  - person_has_partner definition_period set to WEEK

- - - -

These changes:

- Fix or improve an already existing calculation.
- Change non-functional parts of this repository
