### PR TITLE
Added main benefit receiving variables and renamed jobseeker_support_…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 # 17.0.0 - [37](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/37)
 * Added variables:
-  - `social_security__recieving_main_benefit`
+  - `social_security__receiving_main_benefit`
   - `emergency_benefit__receiving`
   - `sole_parent_support__receiving`
   - `supported_living_payment__receiving`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+# 17.0.0 - [37](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/37)
+* Added variables:
+  - `social_security__recieving_main_benefit`
+  - `emergency_benefit__receiving`
+  - `sole_parent_support__receiving`
+  - `supported_living_payment__receiving`
+  - `young_parent_payment__receiving`
+  - `youth_payment__receiving`
+* Renamed variables:
+  - `jobseeker_benefit__granted` to `jobseeker_support__granted`
+
+# Changelog
 # 16.0.0 - [35](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/35)
 * Change to contributing.md and coding patterns
 * Updated spelling of dependant to dependent when used as an adjective

--- a/openfisca_aotearoa/tests/social_security/jobseeker_support/jobseeker_support__base.yaml
+++ b/openfisca_aotearoa/tests/social_security/jobseeker_support/jobseeker_support__base.yaml
@@ -222,3 +222,9 @@
       2021-W23: [220.65, 0, 0]
       2022-W01: [102.04999, 0, 0]
       2023-W01: [251.5, 0, 0]
+    social_security__recieving_main_benefit:
+      2020-W01: false
+      2021-W01: false
+      2021-W23: false
+      2022-W01: false
+      2023-W01: false

--- a/openfisca_aotearoa/tests/social_security/jobseeker_support/jobseeker_support__base.yaml
+++ b/openfisca_aotearoa/tests/social_security/jobseeker_support/jobseeker_support__base.yaml
@@ -222,7 +222,7 @@
       2021-W23: [220.65, 0, 0]
       2022-W01: [102.04999, 0, 0]
       2023-W01: [251.5, 0, 0]
-    social_security__recieving_main_benefit:
+    social_security__receiving_main_benefit:
       2020-W01: false
       2021-W01: false
       2021-W23: false

--- a/openfisca_aotearoa/tests/social_security/main_benefits.yaml
+++ b/openfisca_aotearoa/tests/social_security/main_benefits.yaml
@@ -25,7 +25,7 @@
       2021-W23: [true, false]
       2022-W01: [true, false]
       2023-W01: [true, false]
-    social_security__recieving_main_benefit:
+    social_security__receiving_main_benefit:
       2020-W01: [false, false]
       2021-W01: [false, false]
       2021-W23: [false, false]
@@ -64,7 +64,7 @@
       2021-W23: [true, false]
       2022-W01: [true, false]
       2023-W01: [true, false]
-    social_security__recieving_main_benefit:
+    social_security__receiving_main_benefit:
       2020-W01: [false, false]
       2021-W01: [true, false]
       2021-W23: [true, false]
@@ -115,7 +115,7 @@
       2021-W23: [true, false]
       2022-W01: [true, false]
       2023-W01: [true, false]
-    social_security__recieving_main_benefit:
+    social_security__receiving_main_benefit:
       2020-W01: [false, false]
       2021-W01: [true, false]
       2021-W23: [true, false]

--- a/openfisca_aotearoa/tests/social_security/main_benefits.yaml
+++ b/openfisca_aotearoa/tests/social_security/main_benefits.yaml
@@ -1,0 +1,123 @@
+- name: >
+    Social Security Act 2018
+    Testing entitled, granted but not receiving main benefits
+  period: 2019-11-26
+  input:
+    persons:
+      "Mama":
+        date_of_birth: 1997-01-01
+        jobseeker_support__granted:
+          2020-W01: true
+          2021-W01: true
+          2021-W23: true
+          2022-W01: true
+          2023-W01: true
+      "Papa":
+        date_of_birth: 1996-01-01
+    families:
+      Whanau:
+        principal: ["Mama"]
+        partners: ["Papa"]
+  output:
+    social_security__granted_main_benefit:
+      2020-W01: [true, false]
+      2021-W01: [true, false]
+      2021-W23: [true, false]
+      2022-W01: [true, false]
+      2023-W01: [true, false]
+    social_security__recieving_main_benefit:
+      2020-W01: [false, false]
+      2021-W01: [false, false]
+      2021-W23: [false, false]
+      2022-W01: [false, false]
+      2023-W01: [false, false]
+- name: >
+    Social Security Act 2018
+    Testing entitled, granted and receiving main benefit
+  period: 2019-11-26
+  input:
+    persons:
+      "Mama":
+        date_of_birth: 1997-01-01
+        jobseeker_support__granted:
+          2020-W01: true
+          2021-W01: true
+          2021-W23: true
+          2022-W01: true
+          2023-W01: true
+        jobseeker_support__receiving:
+          2020-W01: false
+          2021-W01: true
+          2021-W23: true
+          2022-W01: true
+          2023-W01: true
+      "Papa":
+        date_of_birth: 1996-01-01
+    families:
+      Whanau:
+        principal: ["Mama"]
+        partners: ["Papa"]
+  output:
+    social_security__granted_main_benefit:
+      2020-W01: [true, false]
+      2021-W01: [true, false]
+      2021-W23: [true, false]
+      2022-W01: [true, false]
+      2023-W01: [true, false]
+    social_security__recieving_main_benefit:
+      2020-W01: [false, false]
+      2021-W01: [true, false]
+      2021-W23: [true, false]
+      2022-W01: [true, false]
+      2023-W01: [true, false]
+- name: >
+    Social Security Act 2018
+    Testing entitled, granted and receiving different main benefits
+  period: 2019-11-26
+  input:
+    persons:
+      "Mama":
+        date_of_birth: 1997-01-01
+        jobseeker_support__granted:
+          2020-W01: true
+          2021-W01: true
+          2021-W23: true
+          2022-W01: true
+          2023-W01: true
+        jobseeker_support__receiving:
+          2020-W01: false
+          2021-W01: true
+          2021-W23: false
+          2022-W01: false
+          2023-W01: false
+        sole_parent_support__receiving:
+          2020-W01: false
+          2021-W01: false
+          2021-W23: false
+          2022-W01: false
+          2023-W01: true
+        supported_living_payment__receiving:
+          2020-W01: false
+          2021-W01: false
+          2021-W23: true
+          2022-W01: false
+          2023-W01: false
+      "Papa":
+        date_of_birth: 1996-01-01
+    families:
+      Whanau:
+        principal: ["Mama"]
+        partners: ["Papa"]
+  output:
+    social_security__granted_main_benefit:
+      2020-W01: [true, false]
+      2021-W01: [true, false]
+      2021-W23: [true, false]
+      2022-W01: [true, false]
+      2023-W01: [true, false]
+    social_security__recieving_main_benefit:
+      2020-W01: [false, false]
+      2021-W01: [true, false]
+      2021-W23: [true, false]
+      2022-W01: [false, false]
+      2023-W01: [true, false]

--- a/openfisca_aotearoa/variables/acts/social_security/emergency_benefit/emergency_benefit.py
+++ b/openfisca_aotearoa/variables/acts/social_security/emergency_benefit/emergency_benefit.py
@@ -11,3 +11,12 @@ class emergency_benefit__granted(variables.Variable):
     label = "Person is currently granted the Emergency benefit"
     definition_period = periods.WEEK
     reference = "Reference is unclear, but variable is utilised by the phrase: 'granted a main benefit'"
+
+
+class emergency_benefit__receiving(variables.Variable):
+    value_type = bool
+    default_value = False
+    entity = entities.Person
+    label = "Person is currently recieving/being paid the emergency benefit"
+    definition_period = periods.WEEK
+    reference = "Reference is unclear, but concept underpinning the variable assumes it covers both: 'being paid a main benefit' or 'recieving a benefit'"

--- a/openfisca_aotearoa/variables/acts/social_security/interpretation/benefits.py
+++ b/openfisca_aotearoa/variables/acts/social_security/interpretation/benefits.py
@@ -52,7 +52,7 @@ class social_security__granted_main_benefit(variables.Variable):
         return a
 
 
-class social_security__recieving_main_benefit(variables.Variable):
+class social_security__receiving_main_benefit(variables.Variable):
     value_type = bool
     entity = entities.Person
     label = "Person is recieving/being paid a main benefit"

--- a/openfisca_aotearoa/variables/acts/social_security/interpretation/benefits.py
+++ b/openfisca_aotearoa/variables/acts/social_security/interpretation/benefits.py
@@ -41,13 +41,31 @@ class social_security__granted_main_benefit(variables.Variable):
     reference = "https://www.legislation.govt.nz/act/public/2018/0032/latest/whole.html#DLM6784575"
 
     def formula(persons, period, parameters):
-        a = persons("jobseeker_benefit__granted", period) + \
+        a = persons("jobseeker_support__granted", period) + \
             persons("sole_parent_support__granted", period) + \
             (persons("supported_living_payment__granted", period) * (persons("supported_living_payment__restricted_work_capacity", period) + persons("totally_blind", period))) + \
             (persons("supported_living_payment__granted", period) * persons("supported_living_payment__caring_for_another_person", period)) + \
             persons("youth_payment__granted", period) + \
             persons("young_parent_payment__granted", period) + \
             persons("emergency_benefit__granted", period)
+        # b - is defined in section 349 for the purposes of sections 349 to 352
+        return a
+
+
+class social_security__recieving_main_benefit(variables.Variable):
+    value_type = bool
+    entity = entities.Person
+    label = "Person is recieving/being paid a main benefit"
+    definition_period = periods.WEEK
+    reference = "https://www.legislation.govt.nz/act/public/2018/0032/latest/whole.html#DLM6784575"
+
+    def formula(persons, period, parameters):
+        a = persons("jobseeker_support__receiving", period) + \
+            persons("sole_parent_support__receiving", period) + \
+            persons("supported_living_payment__receiving", period) + \
+            persons("youth_payment__receiving", period) + \
+            persons("young_parent_payment__receiving", period) + \
+            persons("emergency_benefit__receiving", period)
         # b - is defined in section 349 for the purposes of sections 349 to 352
         return a
 

--- a/openfisca_aotearoa/variables/acts/social_security/jobseeker_support/jobseeker_support.py
+++ b/openfisca_aotearoa/variables/acts/social_security/jobseeker_support/jobseeker_support.py
@@ -159,7 +159,7 @@ class jobseeker_support__receiving(variables.Variable):
     reference = "https://www.legislation.govt.nz/act/public/2018/0032/latest/whole.html#DLM6783146"
 
 
-class jobseeker_benefit__granted(variables.Variable):
+class jobseeker_support__granted(variables.Variable):
     value_type = bool
     default_value = False
     entity = entities.Person

--- a/openfisca_aotearoa/variables/acts/social_security/sole_parent_support/sole_parent_support.py
+++ b/openfisca_aotearoa/variables/acts/social_security/sole_parent_support/sole_parent_support.py
@@ -53,6 +53,15 @@ class sole_parent_support__granted(variables.Variable):
     reference = "Reference is unclear, but variable is utilised by the phrase: 'granted a main benefit'"
 
 
+class sole_parent_support__receiving(variables.Variable):
+    value_type = bool
+    default_value = False
+    entity = entities.Person
+    label = "Person is currently recieving/being paid sole parent support"
+    definition_period = periods.WEEK
+    reference = "Reference is unclear, but concept underpinning the variable assumes it covers both: 'being paid a main benefit' or 'recieving a benefit'"
+
+
 class sole_parent_support__meets_relationship_qualification(variables.Variable):
     value_type = bool
     default_value = True

--- a/openfisca_aotearoa/variables/acts/social_security/supported_living_payment/supported_living_payment.py
+++ b/openfisca_aotearoa/variables/acts/social_security/supported_living_payment/supported_living_payment.py
@@ -23,6 +23,15 @@ class supported_living_payment__granted(variables.Variable):
     reference = "Reference is unclear, but variable is utilised by the phrase: 'granted a main benefit'"
 
 
+class supported_living_payment__receiving(variables.Variable):
+    value_type = bool
+    default_value = False
+    entity = entities.Person
+    label = "Person is currently recieving/being paid the supported living payment"
+    definition_period = periods.WEEK
+    reference = "Reference is unclear, but concept underpinning the variable assumes it covers both: 'being paid a main benefit' or 'recieving a benefit'"
+
+
 class supported_living_payment__caring_for_another_person(variables.Variable):
     value_type = bool
     entity = entities.Person

--- a/openfisca_aotearoa/variables/acts/social_security/young_parent_payment/young_parent_payment.py
+++ b/openfisca_aotearoa/variables/acts/social_security/young_parent_payment/young_parent_payment.py
@@ -13,6 +13,15 @@ class young_parent_payment__granted(variables.Variable):
     reference = "Reference is unclear, but variable is utilised by the phrase: 'granted a main benefit'"
 
 
+class young_parent_payment__receiving(variables.Variable):
+    value_type = bool
+    default_value = False
+    entity = entities.Person
+    label = "Person is currently recieving/being paid the young parent payment"
+    definition_period = periods.WEEK
+    reference = "Reference is unclear, but concept underpinning the variable assumes it covers both: 'being paid a main benefit' or 'recieving a benefit'"
+
+
 # TODO: Review against the new 2018 act
 class young_parent_payment__entitled(variables.Variable):
     value_type = bool

--- a/openfisca_aotearoa/variables/acts/social_security/youth_payment/exceptional_circumstances.py
+++ b/openfisca_aotearoa/variables/acts/social_security/youth_payment/exceptional_circumstances.py
@@ -14,6 +14,15 @@ class youth_payment__granted(variables.Variable):
     reference = "Reference is unclear, but variable is utilised by the phrase: 'granted a main benefit'"
 
 
+class youth_payment__receiving(variables.Variable):
+    value_type = bool
+    default_value = False
+    entity = entities.Person
+    label = "Person is currently recieving/being paid the youth payment benefit"
+    definition_period = periods.WEEK
+    reference = "Reference is unclear, but concept underpinning the variable assumes it covers both: 'being paid a main benefit' or 'recieving a benefit'"
+
+
 class youth_payment__single_young_person_exceptional_circumstances(variables.Variable):
     value_type = bool
     entity = entities.Person


### PR DESCRIPTION
* Tax and benefit system evolution. Minor change.
* Impacted periods: all.
* Impacted areas: `openfisca_aotearoa/variables/acts/social_security/`
* Details:
* Added variables:
  - `social_security__receiving_main_benefit`
  - `emergency_benefit__receiving`
  - `sole_parent_support__receiving`
  - `supported_living_payment__receiving`
  - `young_parent_payment__receiving`
  - `youth_payment__receiving`
* Renamed variables:
  - `jobseeker_benefit__granted` to `jobseeker_support__granted`
- - - -

These changes:

- Impact the OpenFisca-Aotearoa public API (for instance renaming or removing a variable)
- Add a new feature (for instance adding a variable)
