### PR TITLE
Updated social_security__residential_requirement to week period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+# 17.1.0 - [38](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/38)\\
+* Other changes:
+  - `social_security__residential_requirement` period changed from monthly to weekly
+  - `social_security__ordinarily_resident_in_new_zealand` period changed from monthly to eternity
+
+# Changelog
 # 16.0.0 - [35](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/35)
 * Change to contributing.md and coding patterns
 * Updated spelling of dependant to dependent when used as an adjective

--- a/openfisca_aotearoa/tests/social_security/jobseeker_support/jobseeker_support__entitled.yaml
+++ b/openfisca_aotearoa/tests/social_security/jobseeker_support/jobseeker_support__entitled.yaml
@@ -4,8 +4,7 @@
     jobseeker_support__work_gap: [true, true]
     jobseeker_support__available_for_work: [true, true]
     jobseeker_support__age_requirement: [true, false]
-    social_security__residential_requirement:
-      month:2019-01:2: [true, true]
+    social_security__residential_requirement: [true, true]
     jobseeker_support__minimum_income: [true, true]
   output:
     jobseeker_support__entitled: [true, false]
@@ -19,8 +18,7 @@
 # age_requirement dependancies extended
     jobseeker_support__work_gap: [true, true, true, true]
     jobseeker_support__available_for_work: [true, true, true, true]
-    social_security__residential_requirement:
-      month:2019-01:2: [true, true, true, true]
+    social_security__residential_requirement: [true, true, true, true]
     jobseeker_support__minimum_income: [true, true, true, true]
   output:
     jobseeker_support__age_requirement: [true, false, true, false]
@@ -38,8 +36,7 @@
 # work_gap dependancies extended
     jobseeker_support__available_for_work: [true, true, true, true, true, true, true, true, true, true, true]
     jobseeker_support__age_requirement: [true, true, true, true, true, true, true, true, true, true, true]
-    social_security__residential_requirement:
-      month:2019-01:2: [true, true, true, true, true, true, true, true, true, true, true]
+    social_security__residential_requirement: [true, true, true, true, true, true, true, true, true, true, true]
     jobseeker_support__minimum_income: [true, true, true, true, true, true, true, true, true, true, true]
   output:
     jobseeker_support__work_gap: [true, false, true, false, true, true, false, false, false, true, false]
@@ -54,8 +51,7 @@
 # available_for_work dependancies extended
     jobseeker_support__work_gap: [true, true, true, true, true, true, true]
     jobseeker_support__age_requirement: [true, true, true, true, true, true, true]
-    social_security__residential_requirement:
-      month:2019-01:2: [true, true, true, true, true, true, true]
+    social_security__residential_requirement: [true, true, true, true, true, true, true]
     jobseeker_support__minimum_income: [true, true, true, true, true, true, true]
   output:
     jobseeker_support__entitled: [true, false, true, false, false, true, true]

--- a/openfisca_aotearoa/tests/social_security/residence_for_benefits.yaml
+++ b/openfisca_aotearoa/tests/social_security/residence_for_benefits.yaml
@@ -1,5 +1,5 @@
 - name: Test for residence status appropriate for recieving benefits for 1964 ACT
-  period: 2017-08
+  period: 2017-W32
   absolute_error_margin: 0
   input:
     persons:
@@ -25,17 +25,20 @@
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
       Mary:
         citizenship__citizen: true
-        immigration__recognised_refugee: true
+        immigration__recognised_refugee:
+          2017-08: true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         social_security__ordinarily_resident_in_country_with_reciprocity_agreement: true
       Barry:
         immigration__permanent_resident: true
-        immigration__protected_person: true
+        immigration__protected_person:
+          2017-08: true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         social_security__ordinarily_resident_in_new_zealand: true
       Larry:
         immigration__resident: true
-        immigration__protected_person: true
+        immigration__protected_person:
+          2017-08: true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: false
         social_security__ordinarily_resident_in_new_zealand: false
   output:
@@ -56,15 +59,16 @@
       - true # Barry
       - true # Larry
     social_security__residential_requirement:
-      - true # mama
-      - true # papa
-      - true # Tama
-      - false # tamahine
-      - true # Mary
-      - true # Barry
-      - false # Larry
+      2017-W31:
+        - true # mama
+        - true # papa
+        - true # Tama
+        - false # tamahine
+        - true # Mary
+        - true # Barry
+        - false # Larry
 - name: Test for residence status appropriate for recieving benefits for 2018 ACT
-  period: 2020-08
+  period: 2020-W32
   absolute_error_margin: 0
   input:
     persons:
@@ -95,20 +99,25 @@
         social_security__ordinarily_resident_in_new_zealand: false
         social_security__resided_continuously_nz_2_years_citizen_or_resident: false
       Mary:
-        immigration__recognised_refugee: false
+        immigration__recognised_refugee:
+          2020-08: false
         immigration__resident: false
         social_security__ordinarily_resident_in_country_with_reciprocity_agreement: true
-        years_resided_continuously_in_new_zealand: 3
+        years_resided_continuously_in_new_zealand:
+          2020-08: 3
       Barry:
         immigration__resident: true
-        immigration__protected_person: true
+        immigration__protected_person:
+          2020-08: true
         social_security__ordinarily_resident_in_new_zealand: true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: false
       Larry:
-        immigration__recognised_refugee: false
+        immigration__recognised_refugee:
+          2020-08: false
         immigration__resident: false
         social_security__ordinarily_resident_in_country_with_reciprocity_agreement: true
-        years_resided_continuously_in_new_zealand: 1
+        years_resided_continuously_in_new_zealand:
+          2020-08: 1
   output:
     citizenship__citizen:
       - false # mama

--- a/openfisca_aotearoa/tests/social_security/young_parent_payment.yaml
+++ b/openfisca_aotearoa/tests/social_security/young_parent_payment.yaml
@@ -10,7 +10,8 @@
         age:
           "2017-10-01": 19
         citizenship__citizen: true
-        social_security__ordinarily_resident_in_new_zealand: true
+        social_security__ordinarily_resident_in_new_zealand:
+          "week:2017-W01:52": true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         monthly_income: 80000.0
       Oliver:
@@ -20,7 +21,8 @@
         age:
           "2017-10-01": 16
         citizenship__citizen: true
-        social_security__ordinarily_resident_in_new_zealand: true
+        social_security__ordinarily_resident_in_new_zealand:
+          "week:2017-W01:52": true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         monthly_income: 0.0
         living_with_parent_or_guardian: true
@@ -32,7 +34,8 @@
         age:
           "2017-10-01": 17
         immigration__permanent_resident: true
-        social_security__ordinarily_resident_in_new_zealand: true
+        social_security__ordinarily_resident_in_new_zealand:
+          "week:2017-W01:52": true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         monthly_income: 0.0
         living_with_parent_or_guardian: false
@@ -63,7 +66,8 @@
   input:
     persons:
       Ruby:
-        social_security__ordinarily_resident_in_new_zealand: true
+        social_security__ordinarily_resident_in_new_zealand:
+          "week:2017-W01:52": true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         social_security__in_a_relationship:
           "week:2017-W01:52": false
@@ -85,7 +89,8 @@
         age:
           "2017-10-01": 16
         citizenship__citizen: true
-        social_security__ordinarily_resident_in_new_zealand: true
+        social_security__ordinarily_resident_in_new_zealand:
+          "week:2017-W01:52": true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         family_scheme__assessable_income_for_month: 10.0
       Oscar:
@@ -98,7 +103,8 @@
         age:
           "2017-10-01": 17
         immigration__permanent_resident: true
-        social_security__ordinarily_resident_in_new_zealand: true
+        social_security__ordinarily_resident_in_new_zealand:
+          "week:2017-W01:52": true
         social_security__resided_continuously_nz_2_years_citizen_or_resident: true
         family_scheme__assessable_income_for_month: 0.0
         youth_payment__single_young_person_exceptional_circumstances: true

--- a/openfisca_aotearoa/variables/acts/social_security/jobseeker_support/jobseeker_support.py
+++ b/openfisca_aotearoa/variables/acts/social_security/jobseeker_support/jobseeker_support.py
@@ -63,7 +63,7 @@ class jobseeker_support__entitled(variables.Variable):
 
         ssa64_88B_2 = persons("jobseeker_support__age_requirement", period)
 
-        ssa64_88B_3 = persons("social_security__residential_requirement", period.first_month)
+        ssa64_88B_3 = persons("social_security__residential_requirement", period)
 
         ssa64_88B_4 = persons("jobseeker_support__minimum_income", period)
 
@@ -85,7 +85,7 @@ class jobseeker_support__entitled(variables.Variable):
 
         ssa20_c = persons("jobseeker_support__age_requirement", period)
 
-        ssa20_d = persons("social_security__residential_requirement", period.first_month)
+        ssa20_d = persons("social_security__residential_requirement", period)
 
         ssa20_e = persons("jobseeker_support__minimum_income", period)
 

--- a/openfisca_aotearoa/variables/acts/social_security/resident.py
+++ b/openfisca_aotearoa/variables/acts/social_security/resident.py
@@ -21,7 +21,7 @@ class social_security__residential_requirement(variables.Variable):
     value_type = bool
     entity = entities.Person
     label = "Residential requirements for certain benefits, calculates for the 1964 and the 2018 Social Security Acts"
-    definition_period = periods.MONTH
+    definition_period = periods.WEEK
     reference = "https://www.legislation.govt.nz/act/public/2018/0032/latest/whole.html#DLM6783138", "https://www.legislation.govt.nz/act/public/1964/0136/latest/whole.html#DLM363796"
     set_input = holders.set_input_dispatch_by_period
 
@@ -30,18 +30,18 @@ class social_security__residential_requirement(variables.Variable):
     # Ref: https://www.legislation.govt.nz/act/public/1964/0136/latest/whole.html#DLM363796
     def formula_1964_12_04(persons, period, parameters):
 
-        ssa64_74aa_1_a = persons("immigration__citizen_or_resident", period)
+        ssa64_74aa_1_a = persons("immigration__citizen_or_resident", period.first_month)
 
-        ssa64_74aa_1_b = persons("social_security__ordinarily_resident_in_new_zealand", period)
+        ssa64_74aa_1_b = persons("social_security__ordinarily_resident_in_new_zealand", period.first_month)
 
-        ssa64_74aa_1_c = persons("immigration__recognised_refugee", period) \
-            + persons("immigration__protected_person", period) \
+        ssa64_74aa_1_c = persons("immigration__recognised_refugee", period.first_month) \
+            + persons("immigration__protected_person", period.first_month) \
             + persons("social_security__resided_continuously_nz_2_years_citizen_or_resident", period)
 
         # ssa64_74aa_1_c_i  - this implied in variable: social_security__resided_continuously_nz_2_years_citizen_or_resident
         # ssa64_74aa_1_c_ii  - this implied in calculation
 
-        ssa64_74aa_1A_a_and_b = persons("social_security__ordinarily_resident_in_country_with_reciprocity_agreement", period)
+        ssa64_74aa_1A_a_and_b = persons("social_security__ordinarily_resident_in_country_with_reciprocity_agreement", periods.ETERNITY)
 
         # ssa64_74aa_2 - this calculation performed by only calling this function in relation to the benefits listed
 
@@ -52,15 +52,15 @@ class social_security__residential_requirement(variables.Variable):
 
         # ssa16_1 - Descriptive, not requiring coding.
 
-        ssa16_2_a = persons("immigration__citizen_or_resident", period) * \
-            persons("social_security__ordinarily_resident_in_new_zealand", period)
+        ssa16_2_a = persons("immigration__citizen_or_resident", period.first_month) * \
+            persons("social_security__ordinarily_resident_in_new_zealand", period.first_month)
 
         ssa16_2_a_i = persons("social_security__resided_continuously_nz_2_years_citizen_or_resident", periods.ETERNITY)
 
-        ssa16_2_a_ii = persons("immigration__recognised_refugee", period) + \
-            persons("immigration__protected_person", period)
+        ssa16_2_a_ii = persons("immigration__recognised_refugee", period.first_month) + \
+            persons("immigration__protected_person", period.first_month)
 
-        ssa16_2_b = persons("social_security__ordinarily_resident_in_country_with_reciprocity_agreement", period) * (persons("years_resided_continuously_in_new_zealand", period) >= 2)
+        ssa16_2_b = persons("social_security__ordinarily_resident_in_country_with_reciprocity_agreement", period) * (persons("years_resided_continuously_in_new_zealand", period.first_month) >= 2)
 
         # ssa16_3 - TODO Useful would be a list of countrys this applies to... we could make country an input.
         # ssa16_4 - MSD can refuse or cancel benefit if person not ordinarily in NZ...
@@ -74,8 +74,7 @@ class social_security__ordinarily_resident_in_new_zealand(variables.Variable):
     value_type = bool
     entity = entities.Person
     label = "is ordinarily resident in New Zealand"
-    definition_period = periods.MONTH
-    set_input = holders.set_input_dispatch_by_period
+    definition_period = periods.ETERNITY
     reference = "https://www.legislation.govt.nz/act/public/2018/0032/latest/whole.html#DLM6784616", "https://www.legislation.govt.nz/act/public/1964/0136/latest/whole.html#DLM360407", "https://www.openlaw.nz/case/2014NZCA611"
 
 

--- a/openfisca_aotearoa/variables/acts/social_security/sole_parent_support/sole_parent_support.py
+++ b/openfisca_aotearoa/variables/acts/social_security/sole_parent_support/sole_parent_support.py
@@ -25,7 +25,7 @@ class sole_parent_support__entitled(variables.Variable):
 
     def formula(persons, period, parameters):
         # The applicant
-        resides_in_nz = persons("social_security__residential_requirement", period)
+        resides_in_nz = persons("social_security__residential_requirement", period.first_week)
         resident_or_citizen = persons("immigration__citizen_or_resident", period)
 
         years_in_nz = persons("sole_parent_support__years_in_nz_requirement", period)

--- a/openfisca_aotearoa/variables/acts/social_security/supported_living_payment/supported_living_payment.py
+++ b/openfisca_aotearoa/variables/acts/social_security/supported_living_payment/supported_living_payment.py
@@ -89,7 +89,7 @@ class supported_living_payment__entitled(variables.Variable):
         # this section must meet the residential requirements in section 74AA.
         immigration__resident_or_citizen = persons("immigration__citizen_or_resident", period)
 
-        resides_in_nz = persons("social_security__residential_requirement", period)
+        resides_in_nz = persons("social_security__residential_requirement", period.first_week)
 
         # # income low enough?
         income = persons("supported_living_payment__below_income_threshold", period)

--- a/openfisca_aotearoa/variables/acts/social_security/young_parent_payment/young_parent_payment.py
+++ b/openfisca_aotearoa/variables/acts/social_security/young_parent_payment/young_parent_payment.py
@@ -45,7 +45,7 @@ class young_parent_payment__entitled(variables.Variable):
 
         # 74AA (2)
         residency = persons(
-            "social_security__residential_requirement", period)
+            "social_security__residential_requirement", period.first_week)
 
         return basic_requirements * (single_requirements + in_relationship_requirements) * residency
 


### PR DESCRIPTION
* Tax and benefit system evolution. Minor change.
* Impacted periods: all.
* Impacted areas: `openfisca_aotearoa/variables/social_security`
* Details:
  - `social_security__residential_requirement` period changed from monthly to weekly
  - `social_security__ordinarily_resident_in_new_zealand` period changed from monthly to eternity

- - - -

These changes:

- Impact the OpenFisca-Aotearoa public API
- Fix or improve an already existing calculation.
