### PR TITLE
Use `social_security__dependent_children` in Accommodation Supplement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+### 19.0.1 - [45](https://github.com/digitalaotearoa/openfisca-aotearoa/pull/45)
+
+* Calculation improvement.
+* Impacted periods: 2018/11/26.
+* Impacted areas: `accommodation_supplement`
+* Details:
+  - Use `social_security__dependent_children`
+
 # 19.0.0 - [44](https://github.com/digitalaotearoa/openfisca-aotearoa/pull/44)
 
 * Calculation improvement:

--- a/openfisca_aotearoa/variables/acts/social_security/accommodation_supplement/situation.py
+++ b/openfisca_aotearoa/variables/acts/social_security/accommodation_supplement/situation.py
@@ -29,12 +29,10 @@ class accommodation_supplement__situation(variables.Variable):
     definition_period = periods.DateUnit.WEEK
 
     def formula_2018_11_26(people, period, _params):
-        families = people.family
-        members = families.members("social_security__dependent_child", period)
         principal = people.has_role(entities.Family.PRINCIPAL)
         mingled = principal * people("social_security__in_a_relationship", period)
         singles = principal * numpy.logical_not(mingled)
-        dependent_children = sum(members)
+        dependent_children = people("social_security__dependent_children", period)
         accommodation_type = people("accommodation_type", period)
 
         # As conditions 1-3 and 4-6 differ only in the accommodation type, we
@@ -79,4 +77,4 @@ class accommodation_supplement__situation(variables.Variable):
         fallback = AccommodationSupplement__Situation.unknown
 
         # And we return the situations corresponding to the conditions.
-        return numpy.select(conditions, situations, fallback)
+        return numpy.select(conditions, situations, fallback.index)

--- a/openfisca_aotearoa/variables/acts/social_security/interpretation/child.py
+++ b/openfisca_aotearoa/variables/acts/social_security/interpretation/child.py
@@ -41,7 +41,7 @@ class social_security__dependent_child(variables.Variable):
 
 
 class social_security__dependent_children(variables.Variable):
-    value_type = float
+    value_type = int
     entity = entities.Person
     label = "number a dependent child (or children)"
     definition_period = periods.WEEK

--- a/openfisca_aotearoa/variables/regulation/social_security/accommodation_supplement/assets.py
+++ b/openfisca_aotearoa/variables/regulation/social_security/accommodation_supplement/assets.py
@@ -21,7 +21,8 @@ class accommodation_supplement__assets_requirement(variables.Variable):
         mingled = principal * people("social_security__in_a_relationship", period)
         singles = principal * numpy.logical_not(mingled)
         cash_assets = people("accommodation_supplement__cash_assets", period)
-        dependent_children = people("social_security__dependent_child", period)
+        children = people("social_security__dependent_children", period) >= 1
+        no_child = numpy.logical_not(children)
 
         cash_assets_principal = people.family.sum(
             cash_assets,
@@ -52,13 +53,13 @@ class accommodation_supplement__assets_requirement(variables.Variable):
 
         ssr2018_15_1_a_ii = (
             + singles
-            * (sum(dependent_children) >= 1)
+            * children
             * (total_cash_assets <= threshold.ssa2018_15_1_a)
             )
 
         ssr2018_15_1_b = (
             + singles
-            * (sum(dependent_children) == 0)
+            * no_child
             * (total_cash_assets <= threshold.ssa2018_15_1_b)
             )
 

--- a/openfisca_aotearoa/variables/regulation/social_security/accommodation_supplement/base.py
+++ b/openfisca_aotearoa/variables/regulation/social_security/accommodation_supplement/base.py
@@ -36,10 +36,8 @@ class accommodation_supplement__base(variables.Variable):
         mingled = principal * people("social_security__in_a_relationship", period)
         singles = principal * numpy.logical_not(mingled)
 
-        # We have no dependant children
-        f_members = people.family.members
-        dependant = sum(f_members("social_security__dependent_child", period))
-        children = dependant >= 1
+        # We have no dependent children
+        children = people("social_security__dependent_children", period) >= 1
         no_child = numpy.logical_not(children)
 
         # (a) for a single beneficiary under the age of 25 years, the maximum

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Aotearoa",
-    version = "19.0.0",
+    version = "19.0.1",
     author = "Digital Aotearoa Collective, originally a New Zealand Government, Service Innovation Lab project",
     description = "OpenFisca tax and benefit system for Aotearoa",
     classifiers = [


### PR DESCRIPTION
* Minor change.
* Impacted periods: 2018/11/26.
* Impacted areas: `accommodation_supplement`
* Details:
  - Use `social_security__dependent_children`

- - - -

These changes:

- Fix or improve an already existing calculation.
