### PR TITLE
Patch to fix second price rise for Sole Parent Support in the same order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 20.0.1 - [49](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/49)
+* Other Changes:
+ - `tests/social_security/sole_parent_support/sole_parent_support__benefit.yaml figure fixed for 2022/23`
+
 # 20.0.0 - [43](https://github.com/govzeroaotearoa/openfisca-aotearoa/pull/43)
 * Added variables:
  - `sole_parent_support__requirement`

--- a/openfisca_aotearoa/parameters/social_security/sole_parent_support/base.yml
+++ b/openfisca_aotearoa/parameters/social_security/sole_parent_support/base.yml
@@ -113,8 +113,9 @@ values:
       reference:
         title: Part 2 -> Clause 1
         href: https://www.legislation.govt.nz/regulation/public/2021/0120/latest/whole.html#LMS494973
+# Note: the order increases it to 425.96 and then to 440.96 further into the document
   2022-04-01:
-    value: 425.96
+    value: 440.96
     metadata:
       reference:
         title: Part 2 -> Clause 1

--- a/openfisca_aotearoa/tests/social_security/sole_parent_support/sole_parent_support__benefit.yaml
+++ b/openfisca_aotearoa/tests/social_security/sole_parent_support/sole_parent_support__benefit.yaml
@@ -85,5 +85,65 @@
     sole_parent_support__benefit:
       - 310.05
       - 0
-
-
+- name: Sole Parent Support Act 2018 — Eligibility Marriage or Civil Union Dissolved Family and $200 income and childcare costs TODO, check outputs manually
+  period: 2023-W05
+  absolute_error_margin: 0
+  input:
+    persons:
+      Koro:
+        sole_parent_support__marriage_or_civil_union_dissolved: true
+        social_security__residential_requirement: true
+        sole_parent_support__age_threshold: true
+        social_security__principal_caregiver:
+          month:2023-01:2: true
+        age:
+          day:2023-01-28:7: 30
+        social_security__income:
+          2023-W05: 200
+        sole_parent_support__weekly_childcare_cost:
+          2023-W05: 30
+      Tamaiti:
+        age: 5
+    families:
+      Whanau:
+        principal: Koro
+        children:
+          - Tamaiti
+  output:
+    sole_parent_support__entitled:
+      - true
+      - false
+    sole_parent_support__benefit:
+      - 434.96
+      - 0
+- name: Sole Parent Support Act 2018 — 2022/23 Eligibility Marriage or Civil Union Dissolved Family and 0 income and childcare costs $0
+  period: 2023-W05
+  absolute_error_margin: 0
+  input:
+    persons:
+      Koro:
+        sole_parent_support__marriage_or_civil_union_dissolved: true
+        social_security__residential_requirement: true
+        sole_parent_support__age_threshold: true
+        social_security__principal_caregiver:
+          month:2023-01:2: true
+        age:
+          day:2023-01-28:7: 30
+        social_security__income:
+          2023-W05: 0
+        sole_parent_support__weekly_childcare_cost:
+          2023-W05: 0
+      Tamaiti:
+        age: 5
+    families:
+      Whanau:
+        principal: Koro
+        children:
+          - Tamaiti
+  output:
+    sole_parent_support__entitled:
+      - true
+      - false
+    sole_parent_support__benefit:
+      - 440.96
+      - 0

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ long_description = (this_directory / "README.md").read_text()  # pylint: disable
 
 setup(
     name = "OpenFisca-Aotearoa",
-    version = "20.0.0",
+    version = "20.0.1",
     author = "Digital Aotearoa Collective, originally a New Zealand Government, Service Innovation Lab project",
     description = "OpenFisca tax and benefit system for Aotearoa",
     classifiers = [


### PR DESCRIPTION
Thanks for contributing to OpenFisca ! Please remove this line, as well as, for each line below, the cases which are not relevant to your contribution :)

* Tax and benefit system evolution. Minor change.
* Impacted periods: from 01/04/2022.
* Impacted areas: `openfisca_aotearoa\parameters\social_security\sole_parent_support\base.yml`
* Details:
  - Second benefit increase in order missed,.

- - - -

These changes:
- Fix or improve an already existing calculation.
